### PR TITLE
Ignore empty lines when calculating tag indentation

### DIFF
--- a/src/Neorg/Parser/Block.hs
+++ b/src/Neorg/Parser/Block.hs
@@ -6,7 +6,7 @@ import Cleff.State
 import Control.Applicative (Alternative (many, (<|>)))
 import Control.Monad (guard, void)
 import Control.Monad.Trans.Class
-import Data.Char (isLetter)
+import Data.Char (isLetter, isSpace)
 import Data.Foldable (Foldable (fold, foldl'))
 import Data.Functor (($>), (<&>))
 import Data.Maybe (catMaybes, maybeToList)
@@ -81,7 +81,12 @@ tag = do
   lines <- tagContentLines
   let args = snd $ head lines
       content = tail $ init lines
-      minContentIndent = if null content then P.pos1 else minimum $ fst <$> content
+      minContentIndent =
+        if null nonEmptyLines
+          then P.pos1
+          else minimum $ fst <$> nonEmptyLines
+        where
+          nonEmptyLines = filter (not . T.all isSpace . snd) content
       (endIndent, end) = last lines
   if T.null end || endIndent < startIndent || minContentIndent < startIndent -- end == "" when no @end tag was provided and thus the end is at eof
     then pure Nothing

--- a/test/Parser.hs
+++ b/test/Parser.hs
@@ -93,6 +93,12 @@ tagTests =
             ),
       testCase "Proper tag indentation" $ parse (tag @(FromList '["code"])) "@code \n  nospaceshere\n    twospaces\n@end" ?== Just (SomeTag (Proxy @"code") Nothing "nospaceshere\n  twospaces\n"),
       testCase "Proper tag indentation 2" $ parse (tag @(FromList '["code"])) "@code \nnospaceshere\n  twospaces\n@end" ?== Just (SomeTag (Proxy @"code") Nothing "nospaceshere\n  twospaces\n"),
+      -- Check that the parser properly ignores empty lines when calculating
+      -- the tag indentaion
+      testCase "Proper tag indentation 3" $
+        parse (blocks @(FromList '["code"])) " @code \n here\n\n @end"
+          ?== V.fromList
+            [PureBlock $ Tag (SomeTag (Proxy @"code") Nothing "here\n\n")],
       testCase "Wrong tag indentation" $ parse (blocks @(FromList '["code"])) "  @code \n  nospaceshere\n    twospaces\n@end" ?== V.fromList [],
       testCase "Wrong tag indentation 2" $ parse (blocks @(FromList '["code"])) "  @code \n nospaceshere\n    twospaces\n  @end" ?== V.fromList []
     ]


### PR DESCRIPTION
The tag parsing code checks that all of the tag's content is properly indented otherwise returns `Nothing`. But the code wasn't taking into account lines that were empty or made only of whitespace characters and some code includes these lines and they are almost never indented.

This is fixed by filtering out lines that are empty or made only of whitespace characters when calculating the minimum content indentation.

Fixes #7