### PR TITLE
When no arguments supplied, use STDIN

### DIFF
--- a/pandoc/Main.hs
+++ b/pandoc/Main.hs
@@ -36,7 +36,13 @@ main = runConvert $ do
       case parsedDocument of
         Left err -> logError err
         Right doc -> convertDocument tagHandler doc >>= liftIO . B.putStr . encode
-    _ -> logError $ T.pack "Supply one norg file as argument"
+    [] -> do
+      fileContent <- liftIO $ T.getContents
+      parsedDocument <- parse (T.pack "<STDIN>") fileContent
+      case parsedDocument of
+        Left err -> logError err
+        Right doc -> convertDocument tagHandler doc >>= liftIO . B.putStr . encode
+    _ -> logError $ T.pack "Supply one norg file, or none, as argument"
 
 type Convert = Eff '[Logging, IOE]
 

--- a/test/Parser.hs
+++ b/test/Parser.hs
@@ -143,6 +143,12 @@ paragraphTests =
             [ PureBlock $ Paragraph (Text "Text1"),
               PureBlock $ Paragraph (Text "Text2")
             ],
+      testCase "Two Paragraph segments" $
+        parse (blocks @'Empty) "Text1\nText2"
+          ?== V.fromList
+            [ PureBlock $ Paragraph (Text "Text1"),
+              PureBlock $ Paragraph (Text "Text2")
+            ],
       testCase "Two sentences with blank space" $
         parse (blocks @'Empty) "Simple sentence.\n   \n   Another sentence.\n\n"
           ?== V.fromList


### PR DESCRIPTION
When no arguments supplied, use STDIN.

This fixes Issue #6 