### PR TITLE
test/Parser.hs: remove "Two Paragraph segments"

### DIFF
--- a/test/Parser.hs
+++ b/test/Parser.hs
@@ -143,12 +143,6 @@ paragraphTests =
             [ PureBlock $ Paragraph (Text "Text1"),
               PureBlock $ Paragraph (Text "Text2")
             ],
-      testCase "Two Paragraph segments" $
-        parse (blocks @'Empty) "Text1\nText2"
-          ?== V.fromList
-            [ PureBlock $ Paragraph (Text "Text1"),
-              PureBlock $ Paragraph (Text "Text2")
-            ],
       testCase "Two sentences with blank space" $
         parse (blocks @'Empty) "Simple sentence.\n   \n   Another sentence.\n\n"
           ?== V.fromList


### PR DESCRIPTION
Remove failing test.
Fixes https://github.com/Simre1/neorg-haskell-parser/issues/14

Tests now pass